### PR TITLE
fix(tools): agree verb number in the SELF-HOSTED.md not-covered sentence

### DIFF
--- a/docs/SELF-HOSTED.md
+++ b/docs/SELF-HOSTED.md
@@ -29,7 +29,7 @@ Each page names the exact settings, quotes where they came from, and states the 
 
 ## What is not here
 
-Portainer are in the same position and are not covered yet. They are missing because nobody has read their documentation carefully enough to name the settings without guessing, not because they do not fit.
+Portainer is in the same position and is not covered yet. It is missing because nobody has read their documentation carefully enough to name the settings without guessing, not because they do not fit.
 
 [Tell us which one you run](https://github.com/msgwing/ZeroSMTP/issues/new/choose) and it moves up the list.
 

--- a/tools/build-app-pages.py
+++ b/tools/build-app-pages.py
@@ -157,6 +157,23 @@ def przecinki(nazwy):
     return ", ".join(nazwy[:-1]) + " and " + nazwy[-1]
 
 
+def zdanie_nieobjete(nieobjete):
+    """Zdanie o niepokrytych aplikacjach z czasownikiem odmienionym przez liczbe.
+
+    Dla jednego elementu potrzebne jest "is"/"It", nie "are"/"They" -
+    przecinki() sam zwraca pojedyncza nazwe, ale zdanie wokol niej
+    zakladalo mnoga liczbe.
+    """
+    nazwy = [n["name"] for n in nieobjete]
+    byc, zaimek = ("is", "It") if len(nazwy) == 1 else ("are", "They")
+    return (
+        f"{przecinki(nazwy)} {byc} in the same position and {byc} not "
+        f"covered yet. {zaimek} {byc} missing because nobody has read their "
+        "documentation carefully enough to name the settings without "
+        "guessing, not because they do not fit."
+    )
+
+
 def zbuduj_indeks(wpisy, aktualizacja, nieobjete=()):
     w = [
         "---",
@@ -198,11 +215,7 @@ def zbuduj_indeks(wpisy, aktualizacja, nieobjete=()):
         "",
         "## What is not here",
         "",
-        (przecinki([n["name"] for n in nieobjete]) +
-         " are in the same position and are not covered yet. They "
-         "are missing because nobody has read their documentation carefully "
-         "enough to name the settings without guessing, not because they do "
-         "not fit.") if nieobjete else
+        zdanie_nieobjete(nieobjete) if nieobjete else
         "Every application measured as a candidate now has a page. Tell us "
         "which one you run and it goes on the list.",
         "",


### PR DESCRIPTION
## Problem

`przecinki()` in tools/build-app-pages.py already collapses a one-element
list to a bare name, but the sentence built around it in
zbuduj_indeks() was hardcoded plural: "... are in the same position and
are not covered yet. They are missing ...". After Wiki.js was added to
data/apps.json (#434), the uncovered list shrank to a single entry
(Portainer), and docs/SELF-HOSTED.md started reading:

  Portainer are in the same position and are not covered yet.

## Fix

Added zdanie_nieobjete(), which builds that sentence and picks
is/It vs are/They based on len(nieobjete), then regenerated
docs/SELF-HOSTED.md from data/apps.json.

## Test plan

- python tools/build-app-pages.py --check now passes clean (11 application pages match data/apps.json)
- Diff on docs/SELF-HOSTED.md is exactly the verb/pronoun fix: "Portainer is in the same position and is not covered yet. It is missing ..."
